### PR TITLE
Fix how jruby parses bytes from protobuf

### DIFF
--- a/ruby/src/main/java/com/google/protobuf/jruby/Utils.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/Utils.java
@@ -202,7 +202,7 @@ public class Utils {
             case BOOL:
                 return (Boolean) value ? runtime.getTrue() : runtime.getFalse();
             case BYTES: {
-                IRubyObject wrapped = RubyString.newString(runtime, ((ByteString) value).toStringUtf8(), ASCIIEncoding.INSTANCE);
+                IRubyObject wrapped = RubyString.newString(runtime, ((ByteString) value).toByteArray(), 0, ((ByteString) value).size(), ASCIIEncoding.INSTANCE);
                 wrapped.setFrozen(true);
                 return wrapped;
             }

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -101,4 +101,13 @@ class EncodeDecodeTest < Test::Unit::TestCase
     assert_match json, "{\"CustomJsonName\":42}"
   end
 
+  def test_encode_decode_bytes
+    m = A::B::C::TestMessage.new(
+      :optional_bytes => (0..255).to_a.pack("C*"),
+    )
+    from = A::B::C::TestMessage.encode(m)
+    m2 = A::B::C::TestMessage.decode(from)
+    assert_equal m.optional_bytes.bytes, m2.optional_bytes.bytes
+  end
+
 end


### PR DESCRIPTION
This should fix the issues we're seeing when trying to parse bytes from protobuf. 