### PR TITLE
Fix gemspec metadata so package can be published

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -8,7 +8,10 @@ Gem::Specification.new do |s|
   s.homepage    = "https://developers.google.com/protocol-buffers"
   s.authors     = ["Protobuf Authors"]
   s.email       = "protobuf@googlegroups.com"
-  s.metadata    = { "source_code_uri" => "https://github.com/protocolbuffers/protobuf/tree/#{git_tag}/ruby" }
+  s.metadata    = { 
+    "source_code_uri" => "https://github.com/redcanaryco/protobuf/tree/#{git_tag}/ruby",
+    "github_repo" => "git@github.com:redcanaryco/protobuf.git"
+  }
   s.require_paths = ["lib"]
   s.files       = Dir.glob('lib/**/*.rb')
   if RUBY_PLATFORM == "java"


### PR DESCRIPTION
Per https://github.community/t/unable-to-push-rubygem-to-package-registry-the-expected-resource-was-not-found/14596/7
Normally the repo name has to match the package name. If it doesn't, you get a 404 error when trying to publish the gem. Adding a bit of metadata fixes this issue. 