### PR TITLE
Fixes to get package to work properly

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "google-protobuf"
-  s.version     = "3.17.3.2"
+  s.version     = "3.17.3.3"
   git_tag       = "v#{s.version.to_s.sub('.rc.', '-rc')}" # Converts X.Y.Z.rc.N to vX.Y.Z-rcN, used for the git tag
   s.licenses    = ["BSD-3-Clause"]
   s.summary     = "Protocol Buffers"
@@ -14,14 +14,14 @@ Gem::Specification.new do |s|
   }
   s.require_paths = ["lib"]
   s.files       = Dir.glob('lib/**/*.rb')
-  if RUBY_PLATFORM == "java"
-    s.platform  = "java"
+  #if RUBY_PLATFORM == "java"
+  #  s.platform  = "java"
     s.files     += ["lib/google/protobuf_java.jar"]
-  else
-    s.files     += Dir.glob('ext/**/*')
-    s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-    s.add_development_dependency "rake-compiler-dock", ">= 1.1.0", "< 2.0"
-  end
+  #else
+  #  s.files     += Dir.glob('ext/**/*')
+  #  s.extensions= ["ext/google/protobuf_c/extconf.rb"]
+  #  s.add_development_dependency "rake-compiler-dock", ">= 1.1.0", "< 2.0"
+  #end
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",
                   "tests/generated_code_test.rb"]

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
-  s.name        = "google-protobuf"
-  s.version     = "3.17.3.3"
+  s.name        = "google-protobuf-java"
+  s.version     = "3.17.3.4"
   git_tag       = "v#{s.version.to_s.sub('.rc.', '-rc')}" # Converts X.Y.Z.rc.N to vX.Y.Z-rcN, used for the git tag
   s.licenses    = ["BSD-3-Clause"]
   s.summary     = "Protocol Buffers"
@@ -14,14 +14,7 @@ Gem::Specification.new do |s|
   }
   s.require_paths = ["lib"]
   s.files       = Dir.glob('lib/**/*.rb')
-  #if RUBY_PLATFORM == "java"
-  #  s.platform  = "java"
-    s.files     += ["lib/google/protobuf_java.jar"]
-  #else
-  #  s.files     += Dir.glob('ext/**/*')
-  #  s.extensions= ["ext/google/protobuf_c/extconf.rb"]
-  #  s.add_development_dependency "rake-compiler-dock", ">= 1.1.0", "< 2.0"
-  #end
+  s.files     += ["lib/google/protobuf_java.jar"]
   s.test_files  = ["tests/basic.rb",
                   "tests/stress.rb",
                   "tests/generated_code_test.rb"]

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "google-protobuf"
-  s.version     = "3.17.3"
+  s.version     = "3.17.3.1"
   git_tag       = "v#{s.version.to_s.sub('.rc.', '-rc')}" # Converts X.Y.Z.rc.N to vX.Y.Z-rcN, used for the git tag
   s.licenses    = ["BSD-3-Clause"]
   s.summary     = "Protocol Buffers"

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "google-protobuf"
-  s.version     = "3.17.3.1"
+  s.version     = "3.17.3.2"
   git_tag       = "v#{s.version.to_s.sub('.rc.', '-rc')}" # Converts X.Y.Z.rc.N to vX.Y.Z-rcN, used for the git tag
   s.licenses    = ["BSD-3-Clause"]
   s.summary     = "Protocol Buffers"


### PR DESCRIPTION
So, github packages doesn't appear to have the concept of platforms. No matter which version I upload (java specific or universal), it treats it as universal (see v .1 for example, which is the java version, but it's treated as universal in packages). 

This causes a problem with bundler. Bundle install sees the universal version, and goes to save it. But since it's the java version packaged as universal, it saves it as `google-protobuf-VERSION-java`. This works with normal ruby, but bundle will fail as it's expecting `google-protobuf-VERSION` as that's what it thinks it installed.

So, the fix that ultimately shook out is to package the java specific version as the universal version *without* denoting it as the java version, which is what this PR accomplishes.